### PR TITLE
nesting : feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4975,7 +4975,7 @@
     },
     "packages/invalid-of-type-selectors": {
       "name": "@mrhenry/stylelint-mrhenry-invalid-of-type-selectors",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.0.11"
@@ -5003,7 +5003,7 @@
     },
     "packages/prop-order": {
       "name": "@mrhenry/stylelint-mrhenry-prop-order",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "stylelint": "^15.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,7 +4989,7 @@
     },
     "packages/nesting": {
       "name": "@mrhenry/stylelint-mrhenry-nesting",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.0.11"

--- a/packages/invalid-of-type-selectors/CHANGELOG.md
+++ b/packages/invalid-of-type-selectors/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
+## 2.0.1
+
+- Fix plugin option `false`
+
 ## 2.0.0
 
-Change rule name to `@mrhenry/stylelint-mrhenry-invalid-of-type-selectors`
+- Change rule name to `@mrhenry/stylelint-mrhenry-invalid-of-type-selectors`
 
 ## 1.0.2
 
-Add support for `stylelint` `15.0.0`
+- Add support for `stylelint` `15.0.0`
 
 ## 1.0.1
 
-Tweak README.md
+- Tweak README.md
 
 ## 1.0.0
 

--- a/packages/invalid-of-type-selectors/package.json
+++ b/packages/invalid-of-type-selectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhenry/stylelint-mrhenry-invalid-of-type-selectors",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Warn when :first-of-type is used with class selectors",
   "main": "stylelint-mrhenry-invalid-of-type-selectors.js",
   "scripts": {

--- a/packages/invalid-of-type-selectors/stylelint-mrhenry-invalid-of-type-selectors.js
+++ b/packages/invalid-of-type-selectors/stylelint-mrhenry-invalid-of-type-selectors.js
@@ -21,6 +21,10 @@ const ofTypeSelectors = [
 
 const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 	return (postcssRoot, postcssResult) => {
+		if (!primaryOption) {
+			return;
+		}
+		
 		postcssRoot.walkRules((rule) => {
 			{
 				const lowerCaseSelector = rule.selector.toLowerCase();

--- a/packages/invalid-of-type-selectors/stylelint-mrhenry-invalid-of-type-selectors.test.js
+++ b/packages/invalid-of-type-selectors/stylelint-mrhenry-invalid-of-type-selectors.test.js
@@ -46,3 +46,18 @@ testRule({
 		},
 	]
 });
+
+testRule({
+	plugins: ["./stylelint-mrhenry-invalid-of-type-selectors.js"],
+	ruleName,
+	config: false,
+
+	accept: [
+		{
+			code: ".class:last-of-type {}",
+			description: "Only a type selector"
+		}
+	],
+
+	reject: []
+});

--- a/packages/nesting/CHANGELOG.md
+++ b/packages/nesting/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 2.1.0
+
+- Allow multiple `&` as long as the general pattern remains (e.g. `&:is(.bar &)`)
+- Add `ignoreAtRules` plugin option so that non-standard things like `@mixins` can be allowed.
+- Improve auto fixing.
+
 ## 2.0.0
 
-Change rule name to `@mrhenry/stylelint-mrhenry-nesting`
+- Change rule name to `@mrhenry/stylelint-mrhenry-nesting`
 
 ## 1.0.3
 

--- a/packages/nesting/CHANGELOG.md
+++ b/packages/nesting/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow multiple `&` as long as the general pattern remains (e.g. `&:is(.bar &)`)
 - Add `ignoreAtRules` plugin option so that non-standard things like `@mixins` can be allowed.
 - Improve auto fixing.
+- Fix plugin option `false`
 
 ## 2.0.0
 

--- a/packages/nesting/README.md
+++ b/packages/nesting/README.md
@@ -35,8 +35,16 @@ This style of CSS aims to be expressive and readable.
 		/* when ".element" has an attribute "data-theme" with value "red" */
 	}
 
+	&:is(body.some-modifier *) {
+		/* when ".element" is a child of <body class="some-modifier"> */
+	}
+
 	&:has(img) {
 		/* when ".element" has a child element of type "img" */
+	}
+
+	@media (prefers-color-scheme: dark) {
+		/* when ".element" is shown in a dark mode context */
 	}
 }
 ```
@@ -51,15 +59,6 @@ This style of CSS aims to be expressive and readable.
 	}
 }
 
-/* valid, the nested is a filter or a condition */
-.foo {
-	&:is(.bar) {
-		color: green;
-	}
-}
-```
-
-```css
 /* invalid, the nested selector is not a "filter" on the elements matched by the parent */
 .foo {
 	+ :focus {
@@ -67,20 +66,9 @@ This style of CSS aims to be expressive and readable.
 	}
 }
 
-/* valid, the nested is a filter or a condition */
+/* invalid, "@custom-selector" is not a conditional at-rule */
 .foo {
-	&:focus {
-		color: green;
-	}
-}
-```
-
-```css
-/* valid, the nested is a filter or a condition */
-.foo {
-	@media (prefers-color-scheme: dark) {
-		color: green;
-	}
+	@custom-selector :--foo .bar;
 }
 ```
 
@@ -97,5 +85,35 @@ module.exports = {
 	rules: {
 		"@mrhenry/stylelint-mrhenry-nesting": true,
 	},
+}
+```
+
+## Optional secondary options
+
+### `ignoreAtRules: [/regex/, "string"]`
+
+Given:
+
+```json
+["/^custom-/i", "mixins"]
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+.foo {
+	@custom-selector :--bar .bar;
+}
+```
+
+```css
+.foo {
+	@CUSTOM-MEDIA --bar (min-width: 320px);
+}
+```
+
+```css
+.foo {
+	@mixins bar;
 }
 ```

--- a/packages/nesting/package.json
+++ b/packages/nesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhenry/stylelint-mrhenry-nesting",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mr. Henry's preferred way of writing nested CSS",
   "publishConfig": {
     "access": "public"

--- a/packages/nesting/stylelint-mrhenry-nesting.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.js
@@ -12,9 +12,6 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 	rejectedMustEndWithPseudo: () => {
 		return `Nested selectors must end with a pseudo selectors.`;
 	},
-	rejectedMustContainOnlyOneAmpersand: () => {
-		return `Nested selectors must only contain a single "&".`;
-	},
 	rejectedNestingDepth: () => {
 		return `Nested rules must be limited to 1 level deep.`;
 	},
@@ -104,19 +101,6 @@ const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 					selectorAST.walkNesting(() => {
 						nestingCounter++;
 					});
-
-					if (nestingCounter > 1) {
-						stylelint.utils.report({
-							message: messages.rejectedMustContainOnlyOneAmpersand(),
-							node: rule,
-							index: 0,
-							endIndex: rule.selector.length,
-							result: postcssResult,
-							ruleName,
-						});
-
-						return;
-					}
 				}
 
 				if (selectorAST.nodes?.[0]?.type !== 'nesting') {

--- a/packages/nesting/stylelint-mrhenry-nesting.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.js
@@ -26,6 +26,10 @@ const meta = {
 
 const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 	return (postcssRoot, postcssResult) => {
+		if (!primaryOption) {
+			return;
+		}
+		
 		const ignoreAtRulesOptions = secondaryOptionObject?.ignoreAtRules ?? [];
 
 		postcssRoot.walkAtRules((atrule) => {

--- a/packages/nesting/stylelint-mrhenry-nesting.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.js
@@ -97,14 +97,13 @@ const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 
 				let nestingCounter = 0;
 				{
-					let nestingCounter = 0;
 					selectorAST.walkNesting(() => {
 						nestingCounter++;
 					});
 				}
 
 				if (selectorAST.nodes?.[0]?.type !== 'nesting') {
-					if (context.fix && nestingCounter === 0) {
+					if (context.fix) {
 						fixSelector(rule, selectorsAST, selectorAST);
 						return;
 					}

--- a/packages/nesting/stylelint-mrhenry-nesting.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.js
@@ -26,6 +26,8 @@ const meta = {
 
 const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 	return (postcssRoot, postcssResult) => {
+		const ignoreAtRulesOptions = secondaryOptionObject?.ignoreAtRules ?? [];
+
 		postcssRoot.walkAtRules((atrule) => {
 			let name = atrule.name.toLowerCase();
 			if (
@@ -36,6 +38,20 @@ const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 			) {
 				// always allowed
 				return;
+			}
+
+			for (const ignoreAtRulesOption of ignoreAtRulesOptions) {
+				if (ignoreAtRulesOption instanceof RegExp) {
+					if (ignoreAtRulesOption.test(name)) {
+						// ignored by regexp match
+						return;
+					}
+				} else {
+					if (name === ignoreAtRulesOption) {
+						// ignored by direct match
+						return;
+					}
+				}
 			}
 
 			let rulesDepth = 0;

--- a/packages/nesting/stylelint-mrhenry-nesting.test.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.test.js
@@ -351,3 +351,22 @@ testRule({
 		},
 	]
 });
+
+testRule({
+	plugins: ["./stylelint-mrhenry-nesting.js"],
+	ruleName,
+	config: [false],
+
+	accept: [
+		{
+			code: "div { @unknown foo; }",
+			description: "Ignore unknown at rule by string"
+		},
+		{
+			code: "div { @yOuR-rule foo; }",
+			description: "Ignore unknown at rule by regexp"
+		},
+	],
+
+	reject: []
+});

--- a/packages/nesting/stylelint-mrhenry-nesting.test.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.test.js
@@ -55,6 +55,10 @@ testRule({
 			code: "div { &:is(& + &) { color: red } }",
 			description: "Multiple &, in pseudo functions",
 		},
+		{
+			code: "div { { color: red; } }",
+			description: "empty selector",
+		},
 	],
 
 	reject: [
@@ -238,13 +242,63 @@ testRule({
 		},
 		{
 			code: ".bar { body.theme-red & { color: magenta; } }",
-			fixed: ".bar { &:is(body.theme-red &) { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red *) { color: magenta; } }",
 			description: "Incorrect shape",
 			message: rule.messages.rejectedMustStartWithAmpersand(),
 			line: 1,
 			column: 8,
 			endLine: 1,
 			endColumn: 24
+		},
+		{
+			code: ".bar { body.theme-red > & { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red > *) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 26
+		},
+		{
+			code: ".bar { body.theme-red + & { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red + *) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 26
+		},
+		{
+			code: ".bar { body.theme-red ~ & { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red ~ *) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 26
+		},
+		{
+			code: ".bar { body.theme-red& { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red&) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 23
+		},
+		{
+			code: ".bar { :focus& { color: magenta; } }",
+			fixed: ".bar { &:focus { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 15
 		},
 		{
 			code: ".bar { body.theme-red .bar { color: magenta; } }",

--- a/packages/nesting/stylelint-mrhenry-nesting.test.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.test.js
@@ -236,5 +236,35 @@ testRule({
 			endLine: 1,
 			endColumn: 14
 		},
+		{
+			code: ".bar { body.theme-red & { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red &) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 24
+		},
+		{
+			code: ".bar { body.theme-red .bar { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red .bar) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 27
+		},
+		{
+			code: ".bar { body.theme-red * { color: magenta; } }",
+			fixed: ".bar { &:is(body.theme-red *) { color: magenta; } }",
+			description: "Incorrect shape",
+			message: rule.messages.rejectedMustStartWithAmpersand(),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 24
+		},
 	]
 });

--- a/packages/nesting/stylelint-mrhenry-nesting.test.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.test.js
@@ -21,7 +21,7 @@ testRule({
 		},
 		{
 			code: "@custom-selector :--foo bar;",
-			description: "Regular conditional media rule"
+			description: "Regular at rule"
 		},
 		{
 			code: "div { @supports (display: grid) { color: green; } }",
@@ -319,6 +319,35 @@ testRule({
 			column: 8,
 			endLine: 1,
 			endColumn: 24
+		},
+	]
+});
+
+testRule({
+	plugins: ["./stylelint-mrhenry-nesting.js"],
+	ruleName,
+	config: [true, { ignoreAtRules: ['unknown', /^YOUR-/i] }],
+
+	accept: [
+		{
+			code: "div { @unknown foo; }",
+			description: "Ignore unknown at rule by string"
+		},
+		{
+			code: "div { @yOuR-rule foo; }",
+			description: "Ignore unknown at rule by regexp"
+		},
+	],
+
+	reject: [
+		{
+			code: "div { @not-yOuR-rule foo; }",
+			description: "@custom-selector",
+			message: rule.messages.rejectedAtRule('not-your-rule'),
+			line: 1,
+			column: 7,
+			endLine: 1,
+			endColumn: 20
 		},
 	]
 });

--- a/packages/nesting/stylelint-mrhenry-nesting.test.js
+++ b/packages/nesting/stylelint-mrhenry-nesting.test.js
@@ -39,6 +39,22 @@ testRule({
 			code: "div { &:not(.foo), &:is(.bar) { color: green; } }",
 			description: "Functional pseudo class selector"
 		},
+		{
+			code: "div { &:is(body.theme-red *) { color: red } }",
+			description: "Alternative to multiple &, in pseudo functions",
+		},
+		{
+			code: "div { &:is(body.theme-red &) { color: red } }",
+			description: "Multiple &, in pseudo functions",
+		},
+		{
+			code: "div { &:is(&&) { color: red } }",
+			description: "Multiple &, in pseudo functions",
+		},
+		{
+			code: "div { &:is(& + &) { color: red } }",
+			description: "Multiple &, in pseudo functions",
+		},
 	],
 
 	reject: [
@@ -97,13 +113,31 @@ testRule({
 			endColumn: 18
 		},
 		{
-			code: "div { &:not(&) { color: red } }",
-			description: "Multiple &, in pseudo functions",
-			message: rule.messages.rejectedMustContainOnlyOneAmpersand(),
+			code: "div { && { color: red } }",
+			description: "Multiple & top level",
+			message: rule.messages.rejectedMustEndWithPseudo(),
 			line: 1,
 			column: 7,
 			endLine: 1,
-			endColumn: 15
+			endColumn: 9
+		},
+		{
+			code: "div { & + & { color: red } }",
+			description: "Multiple & top level",
+			message: rule.messages.rejectedNestingSelectorIncorrectShape(),
+			line: 1,
+			column: 7,
+			endLine: 1,
+			endColumn: 12
+		},
+		{
+			code: "div { & &:focus { color: red } }",
+			description: "Multiple & top level",
+			message: rule.messages.rejectedNestingSelectorIncorrectShape(),
+			line: 1,
+			column: 7,
+			endLine: 1,
+			endColumn: 16
 		},
 		{
 			code: "div { & > bar + .bar { color: red } }",

--- a/packages/prop-order/CHANGELOG.md
+++ b/packages/prop-order/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.0.1
+
+- Fix plugin option `false`
+
 ## 2.0.0
 
-Change rule name to `@mrhenry/stylelint-mrhenry-prop-order`
+- Change rule name to `@mrhenry/stylelint-mrhenry-prop-order`
 
 ## 1.0.10
 

--- a/packages/prop-order/package.json
+++ b/packages/prop-order/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhenry/stylelint-mrhenry-prop-order",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Mr. Henry's preferred order for CSS properties",
   "main": "stylelint-mrhenry-prop-order.js",
   "scripts": {

--- a/packages/prop-order/stylelint-mrhenry-prop-order.js
+++ b/packages/prop-order/stylelint-mrhenry-prop-order.js
@@ -20,6 +20,10 @@ const ignoredAtRules = [
 
 const ruleFunction = (primaryOption, secondaryOptionObject, context) => {
 	return (postcssRoot, postcssResult) => {
+		if (!primaryOption) {
+			return;
+		}
+		
 		postcssRoot.walkRules((rule) => {
 			let parent = rule.parent;
 			while (parent) {

--- a/packages/prop-order/stylelint-mrhenry-prop-order.test.js
+++ b/packages/prop-order/stylelint-mrhenry-prop-order.test.js
@@ -252,3 +252,18 @@ testRule({
 		},
 	]
 });
+
+testRule({
+	plugins: ["./stylelint-mrhenry-prop-order.js"],
+	ruleName,
+	config: false,
+
+	accept: [
+		{
+			code: ".class { margin-left: 10px; margin: 0; }",
+			description: "shorthand after longhand",
+		}
+	],
+
+	reject: []
+});


### PR DESCRIPTION
- Allow multiple `&` as long as the general pattern remains (e.g. `&:is(.bar &)`)
- Add `ignoreAtRules` plugin option so that non-standard things like `@mixins` can be allowed.
- Improve auto fixing.
- Fix plugin option `false`